### PR TITLE
Disable ZFS support to allow images to build

### DIFF
--- a/sd-image-opi3lts.nix
+++ b/sd-image-opi3lts.nix
@@ -17,4 +17,5 @@
       # "ssh-ed25519 AAAAC3NzaC1lZDI1.... username@tld"
     ];
   };
+  boot.supportedFilesystems = lib.mkForce [ "btrfs" "cifs" "f2fs" "jfs" "ntfs" "reiserfs" "vfat" "xfs" ];
 }

--- a/sd-image-opiz2.nix
+++ b/sd-image-opiz2.nix
@@ -17,4 +17,5 @@
       # "ssh-ed25519 AAAAC3NzaC1lZDI1.... username@tld"
     ];
   };
+  boot.supportedFilesystems = lib.mkForce [ "btrfs" "cifs" "f2fs" "jfs" "ntfs" "reiserfs" "vfat" "xfs" ];
 }


### PR DESCRIPTION
Fixes #3

This solution is from: https://discourse.nixos.org/t/how-to-disable-zfs-for-custom-install-image/26828/3